### PR TITLE
Merge in dgryski/go-tinylfu master

### DIFF
--- a/tinylfu.go
+++ b/tinylfu.go
@@ -6,6 +6,7 @@ package tinylfu
 
 import (
 	"container/list"
+
 	"github.com/dgryski/go-metro"
 )
 
@@ -29,7 +30,7 @@ func New(size int, samples int) *T {
 	}
 	slruSize := int(float64(size) * ((100.0 - lruPct) / 100.0))
 	if slruSize < 1 {
-		slruSize  = 1
+		slruSize = 1
 
 	}
 	slru20 := int(0.2 * float64(slruSize))

--- a/tinylfu.go
+++ b/tinylfu.go
@@ -84,6 +84,21 @@ func (t *T) Get(key string) (interface{}, bool) {
 
 func (t *T) Add(key string, val interface{}) {
 
+	if e, ok := t.data[key]; ok {
+		// Key is already in our cache.
+		// `Add` will act as a `Get` for list movements
+		item := e.Value.(*slruItem)
+		item.value = val
+		t.c.add(item.keyh)
+
+		if item.listid == 0 {
+			t.lru.get(e)
+		} else {
+			t.slru.get(e)
+		}
+		return
+	}
+
 	newitem := slruItem{0, key, val, metro.Hash64Str(key, 0)}
 
 	oitem, evicted := t.lru.add(newitem)

--- a/tinylfu_test.go
+++ b/tinylfu_test.go
@@ -1,0 +1,21 @@
+package tinylfu
+
+import "testing"
+
+func TestAddAlreadyInCache(t *testing.T) {
+	c := New(100, 10000)
+
+	c.Add("foo", "bar")
+
+	val, _ := c.Get("foo")
+	if val.(string) != "bar" {
+		t.Errorf("c.Get(foo)=%q, want %q", val, "bar")
+	}
+
+	c.Add("foo", "baz")
+
+	val, _ = c.Get("foo")
+	if val.(string) != "baz" {
+		t.Errorf("c.Get(foo)=%q, want %q", val, "baz")
+	}
+}


### PR DESCRIPTION
this is to address this bug https://github.com/dgryski/go-tinylfu/issues/9

`.Set()`'ing on the same key does not replace existing value, this is reproducible on this fork (and therefore go-redis/cache). 

Reproduced @dgryski's fix. 